### PR TITLE
Fix null pointer exception processing result of "getTotalBandwidthSavedInMB"

### DIFF
--- a/src/desktop/chrome/content/js/main.js
+++ b/src/desktop/chrome/content/js/main.js
@@ -104,8 +104,9 @@ function initInfoPanel(json) {
   var bytesSaved = getBandwidthSavedInMB(json).toFixed(2);
   bytesSavedEl.textContent = "About " + bytesSaved + " MB of bandwidth was saved";
 
-  var totalBytesSaved = getTotalBandwidthSavedInMB().toFixed(2);
+  var totalBytesSaved = getTotalBandwidthSavedInMB();
   if (totalBytesSaved != null) {
+    totalBytesSaved = totalBytesSaved.toFixed(2);
     totalBytesSavedEl.textContent = "Total bandwith saved: " + totalBytesSaved + " MB";
   }
 


### PR DESCRIPTION
This is to resolve Issue #10.

In "initInfoPanel", there is a call to "getTotalBandwidthSavedInMB". This function can return null, for example if there is an exception parsing a preference to a float. However, the invoking code always assumed a non-null result, and was calling ".toFixed(2)" on the result. This has the upshot of preventing the video from actually being displayed.
